### PR TITLE
Esc-4114 Sort migration history

### DIFF
--- a/PowerShell/Tools/BitTitanManagement.ps1
+++ b/PowerShell/Tools/BitTitanManagement.ps1
@@ -172,7 +172,7 @@ function MW-GetMailboxHistory([MigrationProxy.WebApi.Mailbox]$mailbox)
         try
         {
             $attempts++
-            $history = @(Get-MW_MailboxMigration -Ticket (MWHelper-GetTicket) -Environment (MWHelper-ChooseEnvironment) -FilterBy_Guid_MailboxId $mailbox.Id)
+            $history = @(Get-MW_MailboxMigration -Ticket (MWHelper-GetTicket) -Environment (MWHelper-ChooseEnvironment) -FilterBy_Guid_MailboxId $mailbox.Id -SortBy_CreateDate_Ascending)
             return ,$history
         }
         catch


### PR DESCRIPTION
This sorts past migrations so that the latest migration is the last migration in the list.