### PR TITLE
Fix uncaught exception in BitTitanManagement console

### DIFF
--- a/PowerShell/Tools/BitTitanManagement.ps1
+++ b/PowerShell/Tools/BitTitanManagement.ps1
@@ -701,7 +701,6 @@ function MWHelper-CreateMailboxes($connector, [string]$pfListCsvPath)
 
 function GoogleHelper-GetDomainUsers([string]$domainName)
 {
-    Write-Host -Object "poop"
     $users = Get-MigrationWizGoogleUserAccounts -Ticket (MWHelper-GetTicket) -Environment (MWHelper-ChooseEnvironment) -DomainName $domainName
     return $users
 }

--- a/PowerShell/Tools/BitTitanManagement.ps1
+++ b/PowerShell/Tools/BitTitanManagement.ps1
@@ -1089,7 +1089,7 @@ function Helper-WriteDebug([string]$line)
 
 function Helper-LoadMigrationWizModule()
 {
-    if (((Get-Module -Name "BitTitanPowerShell") -ne $null) -or ((Get-InstalledModule -Name "BitTitanManagement") -ne $null))
+    if (((Get-Module -Name "BitTitanPowerShell") -ne $null) -or ((Get-InstalledModule -Name "BitTitanManagement" -ErrorAction SilentlyContinue) -ne $null))
     {
         return;
     }


### PR DESCRIPTION
- Get-InstalledModule throws an exception when it doesn't find the installed module
- Get-Module on the other hand, does not and that is why it doesn't need the -erroraction property