### PR TITLE
Remove leading and trailing whitespaces in public folder paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @lksoe @cynthia-r

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*       @lksoe @cynthia-r

--- a/PowerShell/AutomationExamples/MigrationWiz/ExportMailEnablePublicFolderEmailAddresses.ps1
+++ b/PowerShell/AutomationExamples/MigrationWiz/ExportMailEnablePublicFolderEmailAddresses.ps1
@@ -69,6 +69,8 @@ foreach ($folder in $mailpub)
     if ($pubfolder.parentpath -eq "\")
     {
 	$folderpath = "\" + ($pubfolder.name.trim())
+	$folderpath = $folderpath.Replace(' \', '\')
+        $folderpath = $folderpath.Replace('\ ', '\')
     }
   
     else


### PR DESCRIPTION
Sync changes from the private repository to the public repository to bring a fix to remove whitespaces in public folder paths.